### PR TITLE
sketch possible interface to implement data manipulation

### DIFF
--- a/possible-interfaces.lisp
+++ b/possible-interfaces.lisp
@@ -1,0 +1,27 @@
+;; select: selects a subset of columns from a dataframe.
+(select df col1 col2 col3)
+
+;; filter: filters rows of a dataframe to those that satisfy some conditions.
+(filter df (< col1 col2))
+
+(filter df (and (< col1 col2)
+		(= col2 0)))
+
+;; group-by: groups a dataframe by columns.
+(group-by df col1 col2)
+
+;; mutate: create new variables in a dataframe.
+(mutate df (col4 (/ col2 col3)))
+	      
+(mutate df ((col4 (* col1 col2))
+	    (col5 (string-upcase col3))))
+
+;; arrange: arrange a dataframe by a column
+(arrange df col1 col2)
+
+;; summarize: summarize a dataframe with aggregating functions
+(summarize df ((avg-col1 (mean col1))
+	       (max-col2 (max col2))))
+
+;; head: retrieve the top 5 entries of a dataframe.
+(head df 50)

--- a/src/query.lisp
+++ b/src/query.lisp
@@ -1,0 +1,39 @@
+(uiop:define-package teddy/query
+  (:use #:cl)
+  (:import-from #:hu.dwim.def
+                #:def
+                #:function
+                #:method
+                #:generic)
+  (:import-from #:teddy/data-frame
+                #:get-column
+                #:get-columns
+                #:get-column-names
+                #:get-types
+                #:make-data-frame
+		#:make-iterator
+		#:slice))
+(in-package teddy/query)
+
+(defun select (data-frame &rest columns)
+  "Returns a subset of columns by name from a data frame."
+  (slice data-frame :columns columns))
+
+;; (defun filter (data-frame condition)
+;;   "Returns a subset of rows in a data frame that satisfy a condition."
+;;   data-frame)
+
+;; (defun mutate (data-frame bindings)
+;;   data-frame)
+
+;; (defun arrange (data-frame &rest columns)
+;;   data-frame)
+
+;; (defun group-by (data-frame &rest columns)
+;;   nil)
+
+;; (defun summarize (data-frame aggregations)
+;;   data-frame)
+
+;; (defun head (data-frame num-rows)
+;;   data-frame)

--- a/teddy.asd
+++ b/teddy.asd
@@ -10,7 +10,8 @@
                "teddy/index"
                "teddy/stats"
                "teddy/print"
-               "teddy/plot")
+               "teddy/plot"
+	       "teddy/query")
   :around-compile "asdf-finalizers:check-finalizers-around-compile")
 
 (register-system-packages "cl-ascii-table" '(#:ascii-table))


### PR DESCRIPTION
Hi, 

I would like to propose a possible interface to implement data manipulation. My goal is to start a conversation to take steps forward to improve working with data in lisp and discuss ideas.

The main interface is similar to the successful `dplyr` package https://dplyr.tidyverse.org/ , but they originally come from SQL. 

The main interface is comprised of 6 functions. From the dplyr `dplyr` documentation: 

```
dplyr is a grammar of data manipulation, providing a consistent set of verbs that help you solve the most common data manipulation challenges:

    mutate() adds new variables that are functions of existing variables
    select() picks variables based on their names.
    filter() picks cases based on their values.
    summarise() reduces multiple values down to a single summary.
    arrange() changes the ordering of the rows.

These all combine naturally with group_by() which allows you to perform any operation “by group”. 
```

The package also contains verbs for joining tables.

Notice the initial phrase "grammar of data manipulation". This package can be the DSL of data manipulation, leaving plotting or reading files into tables for other packages in the future.

What are your initial thoughts? 


